### PR TITLE
improve usage of QR: half memory allocation, double speed

### DIFF
--- a/src/lyapunovs.jl
+++ b/src/lyapunovs.jl
@@ -20,7 +20,7 @@ values of the lyapunov exponents.
   `DifferentialEquations` package (see `evolve` or `timeseries` for more info).
 
 [1] : Add reference here.
-"""
+"""	
 function lyapunovs(ds::DiscreteDS, N::Real; Ttr::Int= 100)
   N = convert(Int, N)
   u = deepcopy(ds.state)
@@ -42,11 +42,9 @@ function lyapunovs(ds::DiscreteDS, N::Real; Ttr::Int= 100)
     J = jac(u)
     K = J*Q
 
-    F = qrfact(K)
-    Q .= F[:Q]
-    A_mul_signB!(Q, F[:R]) #ensure QR gives positive diagonal to R
+    Q, R = qr(K)
     for i in 1:D
-      λ[i] += log(abs(F[:R][i,i]))
+      λ[i] += log(abs(R[i,i]))
     end
   end
   λ./N


### PR DESCRIPTION
If '''Q,R = qr(K)''' is done directly instead of first allocating F and then allocating Q, the Lyapunov spectrum can be calculated more than twice as fast and using less than half of the memory.
before:

```
using DynamicalSystems, StaticArrays, BenchmarkTools
henon_eom(x) = @SVector [1.0 - 1.4x[1]^2 + x[2], 0.3*x[1]]
henon = DiscreteDS([0.0, 0.0], henon_eom)
@btime henon_λ = lyapunovs(henon, 10000)
  44.890 ms (590006 allocations: 28.84 MiB)
2-element Array{Float64,1}:
  0.419986
 -1.62396
```


After:

```
using DynamicalSystems, StaticArrays, BenchmarkTools
henon_eom(x) = @SVector [1.0 - 1.4x[1]^2 + x[2], 0.3*x[1]]
henon = DiscreteDS([0.0, 0.0], henon_eom)
@btime henon_λ = lyapunovs(henon, 10000)
  21.638 ms (210007 allocations: 12.82 MiB)
2-element Array{Float64,1}:
  0.419986
 -1.62396 
```
I guess at the end, one should try to do this without any memory allocation, so there is still room for improvement ;-)