### PR TITLE
Loosen dependency lower bounds

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ OrdinaryDiffEq 2.17.0
 ForwardDiff 0.5
 Requires 0.4.3
 LsqFit 0.3.0
-StaticArrays 0.6.2
-StatsBase 0.18.0
-RecursiveArrayTools 0.12.1
-NearestNeighbors 0.3.0
+StaticArrays 0.5.0
+StatsBase 0.8.2
+RecursiveArrayTools 0.12.0
+NearestNeighbors 0.1.0


### PR DESCRIPTION
Pkg.test("DynamicalSystems") works against these versions - best not to
prevent Pkg from installing version combinations that would work correctly